### PR TITLE
Update GitHub CI actions and Python version to 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
   FORCE_COLOR: "1"
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.12"
 
 jobs:
   tests:
@@ -88,7 +88,7 @@ jobs:
         run: "nox -s coverage_report"
 
       - name: "Upload coverage reports to Codecov"
-        uses: "codecov/codecov-action@v4"
+        uses: "codecov/codecov-action@v5"
         with:
           files: "coverage.xml"
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: "Push to dokku server"
-        uses: "dokku/github-action@v1.4.0"
+        uses: "dokku/github-action@v1.10.0"
         with:
           branch: "main"
           git_remote_url: "${{ vars.DOKKU_GIT_REMOTE_URL }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   FORCE_COLOR: "1"
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.12"
 
 jobs:
   build:
@@ -39,7 +39,7 @@ jobs:
         run: "python -m pip install pip nox -c requirements/constraints.txt"
 
       - name: "Setup GitHub Pages"
-        uses: "actions/configure-pages@v4"
+        uses: "actions/configure-pages@v5"
 
       - name: "Build docs via Nox"
         run: "nox -s docs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ["py311"]
+target-version = ["py312"]
 
 [tool.coverage.run]
 branch = true
@@ -33,7 +33,7 @@ known_django = "django"
 sections = "FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 mypy_path = "src"
 plugins = ["mypy_django_plugin.main"]
 exclude = ["migrations"]
@@ -55,7 +55,7 @@ pythonpath = "src"
 DJANGO_SETTINGS_MODULE = "fakester.settings"
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 extend-exclude = ["migrations"]
 
 [tool.ruff.lint]


### PR DESCRIPTION
This submission resolves outdated GitHub CI action warnings and aligns the CI infrastructure with the current Python 3.12 stack used in `requirements.txt`. Tested successfully via `pytest` locally.

---
*PR created automatically by Jules for task [4830909997891280542](https://jules.google.com/task/4830909997891280542) started by @pawelad*