### PR TITLE
🔒 Replace hardcoded SECRET_KEY with randomly generated one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ Available settings:
 ENVIRONMENT='production'
 
 # Django's secret key. Should be kept private and needs to be set on a non-local enviroment.
-# Defualt: "CHANGE_ME"
+# Default: A randomly generated secret key (only in "local" environment)
 # Docs: https://docs.djangoproject.com/en/4.1/ref/settings/#secret-key
 SECRET_KEY='THIS_IS_A_VERY_SECRET_KEY'
 

--- a/src/fakester/settings.py
+++ b/src/fakester/settings.py
@@ -8,6 +8,7 @@ respective sections at the end of the file.
 from pathlib import Path
 
 from django.core.exceptions import ImproperlyConfigured
+from django.core.management.utils import get_random_secret_key
 
 from decouple import Choices, Csv, config
 from dj_database_url import parse as db_url
@@ -26,7 +27,7 @@ ENVIRONMENT = config(
 SECRET_KEY = config("SECRET_KEY", default=None)
 if not SECRET_KEY:
     if ENVIRONMENT == "local":
-        SECRET_KEY = "CHANGE_ME"  # noqa
+        SECRET_KEY = get_random_secret_key()
     else:
         raise ImproperlyConfigured(
             "You need to provide 'SECRET_KEY' when not running a local environment"


### PR DESCRIPTION
### 🎯 What
Fixed a security vulnerability where the Django `SECRET_KEY` was hardcoded to `"CHANGE_ME"` in local environments.

### ⚠️ Risk
Using a hardcoded, predictable secret key, even in local development, can lead to security issues if the environment is exposed or if developers inadvertently use the default configuration in more sensitive environments. It makes session hijacking and other cryptographic attacks trivial.

### 🛡️ Solution
Replaced the hardcoded `"CHANGE_ME"` string with `django.core.management.utils.get_random_secret_key()`. Now, when `ENVIRONMENT` is set to `"local"` and no `SECRET_KEY` is provided in the environment, a new random key is generated on startup. Updated the documentation in `CONTRIBUTING.md` to match this behavior.

---
*PR created automatically by Jules for task [8984037863595309024](https://jules.google.com/task/8984037863595309024) started by @pawelad*