### PR TITLE
🧹 Refactor hack-ish template context assignment in RedirectFormView

### DIFF
--- a/src/redirects/templates/redirects/form.html
+++ b/src/redirects/templates/redirects/form.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block content %}
-  {% if not view.redirect %}
+  {% if not redirect %}
     {# Redirect wasn't saved, show the form #}
     {% include 'redirects/partials/form.html' %}
   {% else %}

--- a/src/redirects/templates/redirects/partials/results.html
+++ b/src/redirects/templates/redirects/partials/results.html
@@ -4,12 +4,12 @@
 
     <p class="lead fw-light text-justify">
       You can now send one of the links below to someone, and it will redirect them to
-      <strong><a href="{{ view.redirect.destination_url }}" target="_blank">{{ view.redirect.destination_url }}</a></strong>
+      <strong><a href="{{ redirect.destination_url }}" target="_blank">{{ redirect.destination_url }}</a></strong>
       (don't tell them that though). How cool is that?
     </p>
 
     <p>
-      {% for url in view.redirect_fakester_links %}
+      {% for url in redirect_fakester_links %}
         <div class="input-group mb-3">
           <input id="fakesterLink{{ forloop.counter }}" class="form-control" type="text" value="{{ url }}" readonly>
           <button class="btn btn-outline-info copy-button" type="button" data-clipboard-target="#fakesterLink{{ forloop.counter }}">

--- a/src/redirects/views.py
+++ b/src/redirects/views.py
@@ -22,9 +22,12 @@ class RedirectFormView(TemplateView):
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         """Add available domains and initialised form to the template."""
-        kwargs["form"] = RedirectModelForm(
-            data=self.request.POST or None,
-            request=self.request,
+        kwargs.setdefault(
+            "form",
+            RedirectModelForm(
+                data=self.request.POST or None,
+                request=self.request,
+            ),
         )
 
         return super().get_context_data(**kwargs)
@@ -32,19 +35,18 @@ class RedirectFormView(TemplateView):
     @method_decorator(ratelimit(key="ip", rate="3/m"))
     def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
         """Handle redirect form saving and default to GET response."""
-        ctx = self.get_context_data(**kwargs)
+        form = RedirectModelForm(data=request.POST, request=request)
 
-        form = ctx["form"]
         if form.is_valid():
             # Add sender IP address
             redirect = form.save(commit=False)
             redirect.author_ip, _ = get_client_ip(self.request)
             redirect.save()
 
-            # TODO: This feels hack-ish...
-            # Add saved object to view in order to access it in the template
-            self.redirect = redirect
-            self.redirect_fakester_links = redirect.get_fakester_links(request)
+            kwargs["redirect"] = redirect
+            kwargs["redirect_fakester_links"] = redirect.get_fakester_links(request)
+
+        kwargs["form"] = form
 
         return super().get(request, *args, **kwargs)
 

--- a/tests/redirects/test_views.py
+++ b/tests/redirects/test_views.py
@@ -107,8 +107,8 @@ class TestRedirectFormView:
         response = client.post(self.url, data)
 
         assert response.status_code == 200
-        assert hasattr(response.context["view"], "redirect")
-        assert isinstance(response.context["view"].redirect, Redirect)
+        assert "redirect" in response.context
+        assert isinstance(response.context["redirect"], Redirect)
 
         redirect = Redirect.objects.get(local_path=data["local_path"])
         assert redirect.destination_url == data["destination_url"]


### PR DESCRIPTION
The "hack-ish" template context assignment in `src/redirects/views.py` has been refactored. Previously, the `RedirectFormView.post` method was assigning `redirect` and `redirect_fakester_links` directly to `self` to make them available in the template. This has been changed to pass these values through the template context via `kwargs`.

Specifically:
1.  **Views:** `RedirectFormView.get_context_data` now uses `kwargs.setdefault("form", ...)` to ensure that if a form is already provided in `kwargs` (e.g., from a `post` request), it isn't overwritten. The `post` method now puts `redirect` and `redirect_fakester_links` into `kwargs` before calling `super().get()`.
2.  **Templates:** `src/redirects/templates/redirects/form.html` and `src/redirects/templates/redirects/partials/results.html` were updated to use `{{ redirect }}` and `{{ redirect_fakester_links }}` directly instead of accessing them via `{{ view.redirect }}` and `{{ view.redirect_fakester_links }}`.
3.  **Tests:** `tests/redirects/test_views.py` was updated to verify that `redirect` is present in `response.context` rather than on the `view` object.

These changes improve the maintainability and follow Django best practices for Class-Based Views.

---
*PR created automatically by Jules for task [10823756711502078902](https://jules.google.com/task/10823756711502078902) started by @pawelad*