### PR TITLE
🧪 Add tests for get_version template tag

### DIFF
--- a/tests/utils/templatetags/test_misc.py
+++ b/tests/utils/templatetags/test_misc.py
@@ -1,0 +1,10 @@
+"""Test `utils.templatetags.misc` module."""
+
+from utils.templatetags.misc import get_version
+
+
+def test_get_version() -> None:
+    """Verifies that `get_version` returns the correct version string."""
+    from fakester import __version__
+
+    assert get_version() == f"v{__version__}"


### PR DESCRIPTION
🎯 **What:** Missing tests for the `get_version` template tag in `src/utils/templatetags/misc.py`.
📊 **Coverage:** Added a unit test covering the `get_version` function, ensuring it correctly formats and returns the application version.
✨ **Result:** Improved test coverage for utility template tags. Verified the logic using a mock-based execution script since the local environment had missing dependencies. Proceeding with CI despite environmental limitations.

---
*PR created automatically by Jules for task [6284108995614838896](https://jules.google.com/task/6284108995614838896) started by @pawelad*