### PR TITLE
🧪 Comprehensive tests for forbidden paths in Redirect.clean

### DIFF
--- a/tests/redirects/test_models.py
+++ b/tests/redirects/test_models.py
@@ -42,6 +42,40 @@ class TestRedirect:
         assert redirect.local_path == "this_is/////a//local_path"
         assert redirect.destination_url == "https://example.com/"
 
+    @pytest.mark.parametrize(
+        "forbidden_path",
+        [
+            "favicon.ico",
+            "/favicon.ico",
+            "robots.txt",
+            "/robots.txt",
+            "humans.txt",
+            "/humans.txt",
+            "ads.txt",
+            "/ads.txt",
+            "sellers.json",
+            "/sellers.json",
+        ],
+    )
+    def test_clean_forbidden_paths(self, forbidden_path: str) -> None:
+        """Fails validation for forbidden static file paths."""
+        redirect = self.model_class(local_path=forbidden_path)
+
+        with pytest.raises(ValidationError, match="Path is not allowed."):
+            redirect.clean()
+
+    @pytest.mark.parametrize(
+        "forbidden_prefix",
+        ["_/", "/_/", ".well-known/", "/.well-known/"],
+    )
+    def test_clean_forbidden_prefixes(self, forbidden_prefix: str) -> None:
+        """Fails validation for forbidden path prefixes."""
+        local_path = f"{forbidden_prefix}foo/bar.html"
+        redirect = self.model_class(local_path=local_path)
+
+        with pytest.raises(ValidationError, match="Path cannot start with"):
+            redirect.clean()
+
     def test_increase_view_count(self, redirect: Redirect) -> None:
         """Redirect view count is increased."""
         assert redirect.views == 0


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
The `Redirect.clean` method handles several forbidden paths and prefixes (e.g., `favicon.ico`, `robots.txt`, `_/`, `.well-known/`), but the existing test suite only covered a subset of these via a shared fixture. This change introduces explicit, comprehensive tests for all currently disallowed values.

### 📊 Coverage: What scenarios are now tested
- All 5 specific forbidden filenames: `favicon.ico`, `robots.txt`, `humans.txt`, `ads.txt`, and `sellers.json`.
- Both forbidden prefixes: `_/` and `.well-known/`.
- Scenarios with and without leading slashes for all the above, verifying the `lstrip("/")` logic in `clean()`.
- Explicit matching of validation error messages to ensure the correct validation logic is triggered.

### ✨ Result: The improvement in test coverage
Test coverage for the `Redirect.clean` method logic is now 100% regarding the specific paths and prefixes it aims to block. The tests follow existing project patterns and are easy to extend if more forbidden values are added in the future.

---
*PR created automatically by Jules for task [7671740494197212248](https://jules.google.com/task/7671740494197212248) started by @pawelad*