### PR TITLE
🧪 Add tests for absolute_path property in Redirect model

### DIFF
--- a/tests/redirects/test_models.py
+++ b/tests/redirects/test_models.py
@@ -30,6 +30,19 @@ class TestRedirect:
         assert redirect.local_path in redirect_str
         assert redirect.destination_url in redirect_str
 
+    @pytest.mark.parametrize(
+        ("local_path", "expected_absolute_path"),
+        [
+            ("foo/bar", "/foo/bar"),
+            ("/foo/bar", "/foo/bar"),
+        ],
+    )
+    def test_absolute_path(self, local_path: str, expected_absolute_path: str) -> None:
+        """`absolute_path` property returns `local_path` with a leading slash."""
+        redirect = self.model_class(local_path=local_path)
+
+        assert redirect.absolute_path == expected_absolute_path
+
     def test_clean(self) -> None:
         """Leading slashes from `local_path` field are removed."""
         data = {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the missing unit tests for the `absolute_path` property in the `Redirect` model.
📊 **Coverage:** The new `test_absolute_path` test case covers two main scenarios:
  - When `local_path` starts without a slash (e.g., `"foo/bar"`), it should return `"/foo/bar"`.
  - When `local_path` starts with a slash (e.g., `"/foo/bar"`), it should return `"/foo/bar"`.
✨ **Result:** The `absolute_path` logic is now explicitly tested and verified, ensuring that path construction remains reliable and correct even after future refactors. The existing project style was maintained by preserving parentheses in `@pytest.mark.django_db()` markers.

---
*PR created automatically by Jules for task [12428088747504825882](https://jules.google.com/task/12428088747504825882) started by @pawelad*